### PR TITLE
Fixes FileNotFoundError error with vit-base-nsfw-detector on ComfyUI startup

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -82,7 +82,7 @@ if not os.path.exists(NSFWDET_MODEL_PATH):
     ]
     for model_url in nd_urls:
         model_name = os.path.basename(model_url)
-        model_path = os.path.join("vit-base-nsfw-detector", model_name)
+        model_path = os.path.join(NSFWDET_MODEL_PATH, model_name)
         download(model_url, model_path, model_name)
 
 dir_facerestore_models = os.path.join(models_dir, "facerestore_models")


### PR DESCRIPTION
The vit-base-nsfw-detector model downloader code is failing as it is attempting to save to the absolute path `'vit-base-nsfw-detector\\*` which causes the error:
``FileNotFoundError: [Errno 2] No such file or directory: 'vit-base-nsfw-detector\\config.json'``

This bug is the cause of these issues:
https://github.com/Gourieff/ComfyUI-ReActor/issues/8
https://github.com/Gourieff/ComfyUI-ReActor/issues/9

This PR fixes that by joining the model names onto `NSFWDET_MODEL_PATH` so they download to `ComfyUI/models/nsfw_detector/vit-base-nsfw-detector/*`.