### PR TITLE
Bugfix for using nodes in video creation, where one source image is used.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1473,10 +1473,10 @@ class MaskHelper:
 
                 face_segment[...,3] = mask[i]
 
-                result = rgba2rgb_tensor(result)
-                result = result.cpu()  # Перемещаем результат обратно на CPU
-
                 pbar.update(1)
+
+        result = rgba2rgb_tensor(result)
+        result = result.cpu()  # Перемещаем результат обратно на CPU
 
         try:
             torch.cuda.empty_cache()


### PR DESCRIPTION
Bugfix for:

File "...\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-ReActor\nodes.py", line 1470, in execute result[image_index] = pasting * paste_mask + result[image_index] * (1. - paste_mask) ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~ RuntimeError: The size of tensor a (3) must match the size of tensor b (4) at non-singleton dimension 2