### PR TITLE
bugfix: Avoid removing modules added by Reactor from `sys.modules`.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,16 +24,8 @@ from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
 
-# Clean up imports
 # Remove repo directory from path
 sys.path.remove(repo_dir)
-# Remove any new modules
-modules_to_remove = []
-for module in sys.modules:
-    if module not in original_modules and not module.startswith("google.protobuf") and not module.startswith("onnx") and not module.startswith("cv2"):
-        modules_to_remove.append(module)
-for module in modules_to_remove:
-    del sys.modules[module]
 
 # Restore original modules
 sys.modules.update(original_webui_modules)


### PR DESCRIPTION
## Intro:
Usually when multiple files try to import a module, the first time will trigger an import, and the imported module will be cached in `sys.modules`. The second time an import happens it will get the module from `sys.modules`.

## Why:
It appears that in `__init__.py` we remove any new module that was added by Reactor, apart from a specific white list.
The meaning of this is that if a module has a side effect when we import it, and the same module will be imported in another place, python won't find it in `sys.modules`, and the side effect will happen again.

To be specific, it causes an issue with `torchao`, which its import triggers the following line:
```
lib.define("int_matmul(Tensor a, Tensor b) -> Tensor")
```

Which will throw this error when it's imported the second time:
```
RuntimeError: Tried to register an operator (torchao::int_matmul(Tensor a, Tensor b) -> Tensor) with the same name and overload name multiple times.
```

## How to Reproduce:
To trigger a second import to `torchao`, add this line to the end of `__init__.py`:
```py
import torchao
```