### PR TITLE
Fix: Remove aggressive sys.modules cleanup causing ComfyUI segfault

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,6 @@ import os
 
 repo_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, repo_dir)
-original_modules = sys.modules.copy()
 
 # Place aside existing modules if using a1111 web ui
 modules_used = [
@@ -24,16 +23,9 @@ from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
 
-# Clean up imports
-# Remove repo directory from path
+# Clean up imports safely - only remove reactor-specific modules
+# Don't aggressively clean sys.modules as this corrupts other nodes' imports
 sys.path.remove(repo_dir)
-# Remove any new modules
-modules_to_remove = []
-for module in sys.modules:
-    if module not in original_modules and not module.startswith("google.protobuf") and not module.startswith("onnx") and not module.startswith("cv2"):
-        modules_to_remove.append(module)
-for module in modules_to_remove:
-    del sys.modules[module]
 
 # Restore original modules
 sys.modules.update(original_webui_modules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "comfyui-reactor"
 description = "(SFW-Friendly) The Fast and Simple Face Swap Extension Node for ComfyUI, based on ReActor SD-WebUI Face Swap Extension"
 version = "0.6.2-b1"
 license = { file = "LICENSE" }
-dependencies = ["insightface==0.7.3", "onnx>=1.14.0", "opencv-python>=4.7.0.72", "numpy==1.26.4", "segment_anything", "albumentations>=1.4.16", "ultralytics"]
+dependencies = ["insightface>=0.7.3", "onnx>=1.14.0", "opencv-python>=4.7.0.72", "numpy>=1.26.4", "segment_anything", "albumentations>=1.4.16", "ultralytics"]
 
 [project.urls]
 Repository = "https://github.com/Gourieff/ComfyUI-ReActor"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 albumentations>=1.4.16
-insightface==0.7.3
+insightface>=0.7.3
 onnx>=1.14.0
 opencv-python>=4.7.0.72
-numpy==1.26.4
+numpy>=1.26.4
 segment_anything
 ultralytics


### PR DESCRIPTION
Fix: Remove aggressive sys.modules cleanup causing ComfyUI segfault

### Issue

ComfyUI crashes with a segmentation fault during startup after loading custom nodes.

### Root Cause Analysis

Comparing PR #194 changes, the diff shows the cleanup code was added:

```python
# Added in PR #194:
modules_to_remove = []
for module in sys.modules:
    if module not in original_modules and not module.startswith("google.protobuf") and not module.startswith("onnx") and not module.startswith("cv2"):
        modules_to_remove.append(module)
for module in modules_to_remove:
    del sys.modules[module]
```

This cleanup removes modules from sys.modules that other custom nodes (loaded after ReActor) depend on, causing segmentation faults.

### Solution

Removing this cleanup resolves the crash:

```python
# In __init__.py, removed:
# - original_modules = sys.modules.copy()
# - The modules_to_remove loop
# Kept:
# - sys.path.remove(repo_dir)
# - sys.modules.update(original_webui_modules)
```

### Additional Change

Unpinned versions for flexibility:
- insightface>=0.7.3
- numpy>=1.26.4

### Question

The cleanup appears designed for a1111 webui compatibility. Would it make sense to add a check to only run cleanup when running in an a1111 context?
